### PR TITLE
Internalize all translations with python gettext

### DIFF
--- a/pympress/__main__.py
+++ b/pympress/__main__.py
@@ -33,22 +33,14 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GLib
 
 import pympress.util
-gettext.install('pympress', pympress.util.get_resource_path('share', 'locale'))
 
 if pympress.util.IS_WINDOWS:
     if os.getenv('LANG') is None:
         lang, enc = locale.getdefaultlocale()
         os.environ['LANG'] = lang
 
-try:
-    # setup the textdomain so Gtk3 can find it
-    libintl = pympress.util.get_gettext_lib()
-    libintl.bindtextdomain('pympress', pympress.util.get_resource_path('share', 'locale'))
-    libintl.bind_textdomain_codeset('pympress', 'UTF-8')
-
-except AttributeError:
-    # disable translations altogether. Pympress will be in English but at least consistenly so.
-    gettext.install('')
+locale.setlocale(locale.LC_ALL, '')
+gettext.install('pympress', pympress.util.get_resource_path('share', 'locale'))
 
 import pympress.ui
 

--- a/pympress/ui.py
+++ b/pympress/ui.py
@@ -268,10 +268,13 @@ class UI:
         self.cache = pympress.surfacecache.SurfaceCache(self.doc, self.config.getint('cache', 'maxpages'))
 
         # Make and populate windows
-        self.builder.set_translation_domain('pympress')
         self.builder.add_from_file(pympress.util.get_resource_path('share', 'xml', 'presenter.glade'))
         self.builder.add_from_file(pympress.util.get_resource_path('share', 'xml', 'highlight.glade'))
         self.builder.add_from_file(pympress.util.get_resource_path('share', 'xml', 'content.glade'))
+
+        # Apply translations to top-level widgets from each file
+        for top_widget in map(self.builder.get_object, ['p_win', 'c_win', 'off_render']):
+            pympress.util.recursive_translate_widgets(top_widget)
 
         # Introspectively load all missing elements from builder
         # This means that all attributes that are None at this time must exist under the same name in the builder


### PR DESCRIPTION
Fixes #19; translations now more consistent; better fix for when we
don't have the C gettext API (e.g. Mac OS X, see #15).