### PR TITLE
Add pygobject3 to brew requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Alternately, you can build your Gtk+3 stack from source using MSVC, see [the Gno
 
 Dependencies can be installed using [Homebrew](https://brew.sh/):
 
-    brew install gtk+3 poppler gobject-introspection
+    brew install gtk+3 poppler gobject-introspection pygobject3
 
 # Contributing
 


### PR DESCRIPTION
After installing 1.2.1 and following the Homebrew instructions, module `gi` was missing; some research revealed I should install `pygobject3`. Here's the error I got:
```
$ pympress
Traceback (most recent call last):
  File "/usr/local/bin/pympress", line 7, in <module>
    from pympress.__main__ import main
  File "/usr/local/lib/python3.7/site-packages/pympress/__main__.py", line 41, in <module>
    from pympress import util
  File "/usr/local/lib/python3.7/site-packages/pympress/util.py", line 33, in <module>
    import gi
ModuleNotFoundError: No module named 'gi'
```