### PR TITLE
Fix the log filename for multi-user systems

### DIFF
--- a/pympress/__main__.py
+++ b/pympress/__main__.py
@@ -25,6 +25,7 @@
 from __future__ import print_function, unicode_literals
 
 import logging
+import os
 import os.path
 import sys
 import getopt
@@ -39,7 +40,10 @@ import platform
 # Setup logging, and catch all uncaught exceptions in the log file.
 # Load pympress.util early (OS and path-specific things) to load and setup gettext translation asap.
 logger = logging.getLogger(__name__)
-logging.basicConfig(filename=os.path.join(tempfile.gettempdir(), 'pympress.log'), level=logging.DEBUG)
+logging.basicConfig(
+    filename=os.path.join(tempfile.gettempdir(), 'pympress.{}.log'.format(os.getuid())),
+    level=logging.DEBUG
+)
 
 
 def uncaught_handler(*exc_info):

--- a/pympress/__main__.py
+++ b/pympress/__main__.py
@@ -32,7 +32,6 @@ import getopt
 import signal
 import locale
 import gettext
-import ctypes
 import tempfile
 import platform
 

--- a/pympress/__main__.py
+++ b/pympress/__main__.py
@@ -35,14 +35,13 @@ import gettext
 import tempfile
 import platform
 
+from pympress import util
+
 
 # Setup logging, and catch all uncaught exceptions in the log file.
 # Load pympress.util early (OS and path-specific things) to load and setup gettext translation asap.
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    filename=os.path.join(tempfile.gettempdir(), 'pympress.{}.log'.format(os.getuid())),
-    level=logging.DEBUG
-)
+logging.basicConfig(filename=util.get_log_path(), level=logging.DEBUG)
 
 
 def uncaught_handler(*exc_info):
@@ -51,8 +50,6 @@ def uncaught_handler(*exc_info):
 
 sys.excepthook = uncaught_handler
 
-
-from pympress import util
 
 if util.IS_WINDOWS:
     if os.getenv('LANG') is None:

--- a/pympress/util.py
+++ b/pympress/util.py
@@ -180,6 +180,20 @@ def list_icons():
     return [get_icon_path(i) for i in icons if os.path.splitext(i)[1].lower() == '.png' and i[:9] == 'pympress-']
 
 
+def get_log_path():
+    if IS_WINDOWS:
+        base_dir = os.environ.get('LOCALAPPDATA') or os.environ.get('APPDATA')
+    elif IS_MAC_OS:
+        base_dir = os.path.expanduser('~/Library/Logs')
+    else:
+        base_dir = os.environ.get('XDG_CACHE_HOME') or os.path.expanduser('~/.cache')
+
+    if not os.path.isdir(base_dir):
+        os.mkdir(base_dir)
+
+    return os.path.join(base_dir, 'pympress.log')
+
+
 def fileopen(f):
     """ Call the right function to open files, based on the platform.
 


### PR DESCRIPTION
On multi-user systems, if two users try to use Pympress (without clearing temporary files in between), the second user will not be able to start Pympress because the log file is already owned by the first user. This pull request fixes the issue by tagging the log filename with the users UID.