### PR TITLE
WIP to support playing videos in macOS

### DIFF
--- a/pympress/media_overlays/base.py
+++ b/pympress/media_overlays/base.py
@@ -113,6 +113,12 @@ class VideoOverlay(builder.Builder):
         self.media_overlay.insert_action_group('media', self.action_map)
 
 
+    def play_pause(self, *args):
+        """ Signal handler to action conversion.
+        """
+        return self.action_map.lookup_action('pause').activate(None)
+
+
     def handle_embed(self, mapped_widget):
         """ Handler to embed the video player in the window, connected to the :attr:`~.Gtk.Widget.signals.map` signal.
         """

--- a/pympress/media_overlays/base.py
+++ b/pympress/media_overlays/base.py
@@ -58,6 +58,28 @@ def get_window_handle(window):
     return gdkdll.gdk_win32_window_get_handle(drawingarea_gpointer)
 
 
+def get_window_nsview(window):
+    """ Uses ctypes to call gdk_quartz_window_get_nsview which is not available
+    in python gobject introspection porting
+
+    Args:
+        window (:class:`~Gdk.Window`): The window for which we want to get the handle
+
+    Returns:
+        The void pointer to the NSView needed by VLC
+    """
+    # get the c gpointer of the gdk window
+    ctypes.pythonapi.PyCapsule_GetPointer.restype = ctypes.c_void_p
+    ctypes.pythonapi.PyCapsule_GetPointer.argtypes = [ctypes.py_object]
+    drawingarea_gpointer = ctypes.pythonapi.PyCapsule_GetPointer(window.__gpointer__, None)
+    # get the NSView
+    gdkdll = ctypes.CDLL('libgdk-3.0.dylib')
+    get_nsview = gdkdll.gdk_quartz_window_get_nsview
+    get_nsview.restype = ctypes.c_void_p
+    get_nsview.argtypes = [ctypes.c_void_p]
+    return get_nsview(drawingarea_gpointer)
+
+
 class VideoOverlay(builder.Builder):
     """ Simple Video widget.
 

--- a/pympress/media_overlays/gst_backend.py
+++ b/pympress/media_overlays/gst_backend.py
@@ -31,7 +31,8 @@ logger = logging.getLogger(__name__)
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gst', '1.0')
-from gi.repository import GLib, Gst
+gi.require_version('GstVideo', '1.0')
+from gi.repository import GLib, Gst, GstVideo
 
 
 from pympress.util import IS_WINDOWS, IS_MAC_OS
@@ -140,7 +141,10 @@ class GstOverlay(base.VideoOverlay):
         bus.connect('sync-message::element', self.on_sync_message)
 
         self.playbin.set_property('uri', self.uri)
-        self.playbin.set_mute(self.muted)
+        try:
+            self.playbin.set_mute(self.muted)
+        except AttributeError:
+            pass
 
         self.playbin.set_state(Gst.State.PLAYING)
 
@@ -156,11 +160,11 @@ class GstOverlay(base.VideoOverlay):
         elif window is None:
             logger.error('No window in which to embed the Gst player!')
         elif IS_WINDOWS:
-            GLib.idle_add(lambda *args: msg.src.set_window_handle(base.get_window_handle(window)))
+            GLib.idle_add(lambda *args: GstVideo.VideoOverlay.set_window_handle(msg.src, base.get_window_handle(window)))
         elif IS_MAC_OS:
-            GLib.idle_add(lambda *args: msg.src.set_window_handle(base.get_window_nsview(window)))
+            GLib.idle_add(lambda *args: GstVideo.VideoOverlay.set_window_handle(msg.src, base.get_window_nsview(window)))
         else:
-            GLib.idle_add(lambda *args: msg.src.set_window_handle(window.get_xid()))
+            GLib.idle_add(lambda *args: GstVideo.VideoOverlay.set_window_handle(msg.src, window.get_xid()))
 
 
     def do_play_pause(self):

--- a/pympress/media_overlays/gst_backend.py
+++ b/pympress/media_overlays/gst_backend.py
@@ -34,7 +34,7 @@ gi.require_version('Gst', '1.0')
 from gi.repository import GLib, Gst
 
 
-from pympress.util import IS_WINDOWS
+from pympress.util import IS_WINDOWS, IS_MAC_OS
 from pympress.media_overlays import base
 
 
@@ -157,6 +157,8 @@ class GstOverlay(base.VideoOverlay):
             logger.error('No window in which to embed the Gst player!')
         elif IS_WINDOWS:
             GLib.idle_add(lambda *args: msg.src.set_window_handle(base.get_window_handle(window)))
+        elif IS_MAC_OS:
+            GLib.idle_add(lambda *args: msg.src.set_window_handle(base.get_window_nsview(window)))
         else:
             GLib.idle_add(lambda *args: msg.src.set_window_handle(window.get_xid()))
 

--- a/pympress/media_overlays/vlc_backend.py
+++ b/pympress/media_overlays/vlc_backend.py
@@ -35,7 +35,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import GLib
 
-from pympress.util import IS_WINDOWS
+from pympress.util import IS_WINDOWS, IS_MAC_OS
 from pympress.media_overlays import base
 
 
@@ -73,6 +73,8 @@ class VlcOverlay(base.VideoOverlay):
             return False
         elif IS_WINDOWS:
             self.player.set_hwnd(base.get_window_handle(window))  # get_property('window')
+        elif IS_MAC_OS:
+            self.player.set_nsobject(base.get_window_nsview(window))
         else:
             self.player.set_xwindow(window.get_xid())
         return False


### PR DESCRIPTION
Tries to enable playing embedded videos in pympress (#62) by finding the XQuartz window ids, which should be `NSObject*`, and passing them on to libvlc and GsPlayer.