### PR TITLE
Add Screensaving on Wayland

### DIFF
--- a/pympress/share/locale/pympress.pot
+++ b/pympress/share/locale/pympress.pot
@@ -448,3 +448,5 @@ msgstr ""
 msgid "{}, {}, {}, {}, or {}"
 msgstr ""
 
+msgid "Fullscreen Presentation running"
+msgstr ""


### PR DESCRIPTION
This adds the possibility of screensaving to Wayland sessions. It will call a dbus interface to tell the compositor, that we want the screen to be on.
This adds dbus as an optional dependency.
This method should also work on X11 but I didn't test it and therefore this is only used on wayland for now.