### PR TITLE
Fix incorrect document member access

### DIFF
--- a/pympress/document.py
+++ b/pympress/document.py
@@ -688,7 +688,7 @@ class Document(object):
                 if action.type == Poppler.ActionType.GOTO_DEST:
                     title = action.goto_dest.title
                     if action.goto_dest.dest.type == Poppler.DestType.NAMED:
-                        dest = self.parent.doc.find_dest(action.goto_dest.dest.named_dest)
+                        dest = self.doc.find_dest(action.goto_dest.dest.named_dest)
                         page = dest.page_num - 1
                     elif action.goto_dest.dest.type == Poppler.DestType.UNKNOWN:
                         raise AssertionError('Unknown type of destination')


### PR DESCRIPTION
Poppler document is stored in self.doc.

This fixes the timing breakdown not opening. Exception:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/pympress/ui.py", line 1218, in show_timing_report
    self.timing.show(int(self.talk_time.delta), self.doc.get_structure(), self.doc.page_labels)
  File "/usr/lib/python3.8/site-packages/pympress/document.py", line 716, in get_structure
    lower_bound = max(index)
ValueError: max() arg is an empty sequence
```