### PR TITLE
Update aur package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here is what the 2 screen setup looks like, with a big notes slide next to 2 sma
 
   Or using any other tool to manage AUR packages (yay, pacaur, etc.):
 
-      yay -S pympress
+      yay -S python-pympress
       pacman -S poppler-glib  # dependency temporarily missing from AUR package
 
 - macOS ![apple logo][apple] using [Homebrew](https://brew.sh/) ![homebrew version badge][homebrew_version]


### PR DESCRIPTION
In the README the aur package pympress is referenced. The correct name of this package is python-pympress and used in the earlier example for manual creation.