### PR TITLE
Add some keywords to .desktop file

### DIFF
--- a/pympress/share/applications/pympress.desktop
+++ b/pympress/share/applications/pympress.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Categories=Office;Viewer;Presentation;GTK;
+Keywords=Presentation;Dual-Screen;Beamer;
 Comment=A simple yet powerful PDF reader designed for dual-screen presentations
 Exec=pympress %f
 Icon=pympress


### PR DESCRIPTION
Suggests some keywords for the .desktop file.

Whilst `Keywords` is not required [1] by the spec, it is encouraged [2],[3]

[1] https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
[2] https://lintian.debian.org/tags/desktop-entry-lacks-keywords-entry
[3] https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords


