### PR TITLE
Video support: only show gstreamer output after player is initialized

### DIFF
--- a/pympress/media_overlays/base.py
+++ b/pympress/media_overlays/base.py
@@ -255,7 +255,7 @@ class VideoOverlay(builder.Builder):
             self.parent.reorder_overlay(self.media_overlay, 2)
             self.resize()
             self.parent.queue_draw()
-        self.media_overlay.show()
+        self.media_overlay.hide() # hide it initially; it will be shown in the play function
 
 
     def do_hide(self, *args):

--- a/pympress/media_overlays/gst_backend.py
+++ b/pympress/media_overlays/gst_backend.py
@@ -101,6 +101,7 @@ class GstOverlay(base.VideoOverlay):
     def on_play(self, *args):
         """ Start the scroll bar updating process.
         """
+        self.media_overlay.show() # player initialized; show the video now
         GLib.idle_add(self.do_update_duration)
         GLib.timeout_add(200, self.do_update_time)
 


### PR DESCRIPTION
When having one (or more) videos on a slide there is the following
effect:

* First time opening this slide: 1+ video frames are black; then the
  video starts.
* Second time opening this slide: Video seems to start on second 2 or 3
  and then suddenly jumps backwards.

It seems like this is caused by showing the video output before the
player is fully initialized. This commit only shows the output after
the video is initialized and avoid both effects.

Tested on Ubuntu 20.04 with LaTeX Beamer slides.