### PR TITLE
Document media fix for brew installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ To enable media playback, you need to have either:
 - Gstreamer installed (enabled by default), with plugins gstreamer-good/-bad/-ugly based on which codecs you need, or
 - VLC installed (and the python-vlc module), with `enabled = on` under the `[vlc]` section of your config file.
 
+On macOS, issues with the gstreamer brew formula may require users to set `GST_PLUGIN_SYSTEM_PATH` manually. For default homebrew configurations the value should be `/opt/homebrew/lib/gstreamer-1.0/`. Make sure to set this environmental variable globally, or pympress might not pick it up.
+
 To produce PDFs with media inclusion, the ideal method is to use beamer’s multimedia package, always with `\movie`:
 
 ```latex


### PR DESCRIPTION
Brew installations of pympress might not be able to play media, as the brew formula for gstreamer is broken.
Fixing this requires the manual setting of an environmental variable.