### PR TITLE
Hide video sink for audio files

### DIFF
--- a/pympress/media_overlays/gst_backend.py
+++ b/pympress/media_overlays/gst_backend.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gst', '1.0')
-from gi.repository import GLib, Gst
+from gi.repository import GLib, Gst, Gio
 
 
 from pympress.media_overlays import base
@@ -43,6 +43,8 @@ class GstOverlay(base.VideoOverlay):
 
     #: A :class:`~Gst.Playbin` to be play videos
     playbin = None
+    #: The mime type of the media file
+    media_type = ''
 
     def __init__(self, *args, **kwargs):
         # Create GStreamer playbin
@@ -82,6 +84,7 @@ class GstOverlay(base.VideoOverlay):
         Args:
             filepath (`pathlib.Path`): The path to the media file path
         """
+        self.media_type, _ = Gio.content_type_guess(filepath.as_uri())
         self.playbin.set_property('uri', filepath.as_uri())
         self.playbin.set_state(Gst.State.READY)
 
@@ -101,7 +104,8 @@ class GstOverlay(base.VideoOverlay):
         """
         GLib.idle_add(self.do_update_duration)
         GLib.timeout_add(200, self.do_update_time)
-        self.sink.props.widget.show()
+        if not self.media_type.startswith('audio'):
+            self.sink.props.widget.show()
 
 
     def do_update_duration(self, *args):


### PR DESCRIPTION
The canonical way to include sound files in LaTeX beamer is to use the `\movie` command of the `multimedia` package. This also works in pympress, however, it replaces the text link (or whatever is used) with a black box while the audio is playing. See the attached minimal working example for a `.tex`, `.ogg` and `.pdf` file displaying that behavior: [test.zip](https://github.com/Cimbali/pympress/files/10929420/test.zip)

This PR is a straightforward fix:
* In the `GstOverlay`, define a `media_type` attribute that is overridden during construction (which calls `set_file`). I followed the original code to create a class attribute `media_type` that is later shadowed by an instance attribute. (Which may or may not have been intentional, see https://www.bruceeckel.com/2022/05/11/misunderstanding-python-class-attributes/. It's also not done consistently, e.g., `sink` does not have a corresponding class attribute. I'd also be fine removing the class attribute and setting an instance attribute in the constructor instead.)
* In `set_file`, ask `Gio` to guess the mime type from the file extension. This works fine as long as the extension is sane. If a user has a video file with an audio extension, it will be mistaken for an audio file, but I guess we could live with that.
* In `on_play`, only unhide the video sink if the mime type does not start with `audio`. This is more defensive than only showing the video sink if the mime type starts with `video`, so it should not break things when mime type guessing did not work.

Let me know if you'd like to see any changes! And thank you for maintaining pympress, I think it solves all the issues I had with pdfpc or evince :tada: 