### PR TITLE
Support custom media start position

### DIFF
--- a/pympress/document.py
+++ b/pympress/document.py
@@ -243,7 +243,8 @@ class Link(object):
 
 #: A class that holds all the properties for media files
 Media = collections.namedtuple('Media', ['relative_margins', 'filename', 'autoplay', 'repeat', 'poster',
-                                         'show_controls', 'type'], defaults=[False, False, False, False, ''])
+                                         'show_controls', 'type', 'start_pos'],
+                               defaults=[False, False, False, False, '', 0.])
 
 
 class Page(object):
@@ -323,6 +324,7 @@ class Page(object):
                 movie_options = {'show_controls': movie.show_controls(), 'poster': movie.need_poster()}
                 try:
                     movie_options['repeat'] = movie.get_play_mode() == Poppler.MoviePlayMode.REPEAT
+                    movie_options['start_pos'] = movie.get_start() / 1e9
                     # NB: autoplay not part of Poppler’s MovieActivationParameters struct
                 except AttributeError:
                     pass  # Missing functions in pre-21.04 Poppler versions

--- a/pympress/media_overlays/base.py
+++ b/pympress/media_overlays/base.py
@@ -69,6 +69,8 @@ class VideoOverlay(builder.Builder):
     repeat = False
     #: `str` representing the mime type of the media file
     media_type = ''
+    #: `float` giving the initial starting position for playback
+    start_pos = 0.
 
     #: `bool` that tracks whether the user is dragging the position
     dragging_position = False
@@ -102,6 +104,7 @@ class VideoOverlay(builder.Builder):
         else:
             content_type, _ = Gio.content_type_guess(media.filename.as_uri())
             self.media_type = Gio.content_type_get_mime_type(content_type)
+        self.start_pos = media.start_pos
         self._set_file(media.filename)
 
         self.autoplay = media.autoplay
@@ -170,7 +173,7 @@ class VideoOverlay(builder.Builder):
         if not self.repeat:
             self.action_map.lookup_action('stop').activate()
         else:
-            self.action_map.lookup_action('set_time').activate(GLib.Variant.new_double(0))
+            self.action_map.lookup_action('set_time').activate(GLib.Variant.new_double(self.start_pos))
 
 
     def update_margins_for_page(self, page_type):


### PR DESCRIPTION
LaTeX beamer's `\movie` command from the `multimedia` package allows to specify a starting position for playback of the embedded media. E.g., `\movie[start=50s]{placeholder}{moviefile.mp4}` is supposed to result in a movie that starts playback from second 50. This can be useful if you only need a specific portion and don't want to cut up the media files beforehands.

Poppler can read this information (and [some more](https://gjs-docs.gnome.org/poppler018~0.18-movie/): there's also the volume and the playback rate, which would be easy to set for gstreamer), so that at least wouldn't be a hurdle for pympress.

My idea would be to start playback at the given starting position when the placeholder was clicked, but still show the full progress bar and allow skipping anywhere (not sure what other PDF viewers do, or if there is a rule to follow). When the movie is stopped (and thus the overlay disappears) and started again, it should again start at the given starting position.

Due to my very incomplete knowledge of gstreamer, I haven't been able to find a good spot for placing the seek command. If I do it directly after setting the pipeline to the `READY` state (which happens on loading the frame, not on clicking the placeholder), seeking fails. This is in line with the [gstreamer documentation](https://gstreamer.freedesktop.org/documentation/gstreamer/gstelement.html?gi-language=c#gst_element_seek_simple); only some elements support seeking in `READY` state. I'm not sure where to hook into the next state change (to `PLAYING`), or if there is a better solution. I can run the `seek` from `do_update_duration` (at that stage, gstreamer has loaded the file and started playback), but that seems to trigger another `do_update_duration` so I have to guard it against re-running with some boolean flag. Not the way it's meant to be played :)

There's [a suggestion on stackoverflow](https://stackoverflow.com/questions/60183871/gstreamer-c-seeking-before-starting-any-playback) to set the pipeline to `PAUSED`, wait for the state change, trigger the seek and only then set it to `PLAY`. Maybe that would be an option as well, but I don't know yet how to wait for a state change (ideally this should probably even happen asynchronously).

Any ideas or hints are welcome!