### PR TITLE
Fix media mimetype reading

### DIFF
--- a/pympress/media_overlays/base.py
+++ b/pympress/media_overlays/base.py
@@ -97,8 +97,8 @@ class VideoOverlay(builder.Builder):
         # medias, here the actions are scoped to the current widget
         self.action_map = action_map
         self.media_overlay.insert_action_group('media', self.action_map)
-        if media.type:
-            self.media_type = media.type
+        if media.content_type:
+            self.media_type = media.content_type
         else:
             content_type, _ = Gio.content_type_guess(media.filename.as_uri())
             self.media_type = Gio.content_type_get_mime_type(content_type)

--- a/pympress/media_overlays/gst_backend.py
+++ b/pympress/media_overlays/gst_backend.py
@@ -27,6 +27,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import gi
+gi.require_version('Gst', '1.0')
 gi.require_version('Gtk', '3.0')
 from gi.repository import GLib, Gst
 


### PR DESCRIPTION
One of the changes on top of #273 fails for me with:
```
  File ".../pympress/media_overlays/base.py", line 100, in __init__
    if media.type:
AttributeError: 'Media' object has no attribute 'type'
```
I guarded it with a `getattr` call, but I'm not sure if that's the correct fix. Did that attribute exist for you? Does it depend on the poppler version? Or is there some mixup between [poppler.media](https://gjs-docs.gnome.org/poppler018~0.18/poppler.media) and [poppler.movie](https://gjs-docs.gnome.org/poppler018~0.18/poppler.movie)?

In addition, I got a warning:
```
.../pympress/media_overlays/gst_backend.py:31: PyGIWarning: Gst was imported without specifying a version first. Use gi.require_version('Gst', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import GLib, Gst
```
I followed the suggestion to ask for Gst 1.0.