### PR TITLE
Fix muting audio in gstreamer backend

### DIFF
--- a/pympress/media_overlays/gst_backend.py
+++ b/pympress/media_overlays/gst_backend.py
@@ -95,10 +95,12 @@ class GstOverlay(base.VideoOverlay):
         """
         # mute by disabling/enabling audio output
         flags = self.playbin.get_property('flags')
+        flag_values = {f.value_nicks[0]: value
+                       for value, f in flags.__class__.__flags_values__.items()}
         if value:
-            flags = flags & ~0x02
+            flags = flags & ~flag_values['audio']
         else:
-            flags = flags | 0x02
+            flags = flags | flag_values['audio']
         self.playbin.set_property('flags', flags)
         return False
 

--- a/pympress/media_overlays/gst_backend.py
+++ b/pympress/media_overlays/gst_backend.py
@@ -93,7 +93,13 @@ class GstOverlay(base.VideoOverlay):
         Args:
             value (`bool`): `True` iff this player should be muted
         """
-        self.playbin.set_property('mute', value)
+        # mute by disabling/enabling audio output
+        flags = self.playbin.get_property('flags')
+        if value:
+            flags = flags & ~0x02
+        else:
+            flags = flags | 0x02
+        self.playbin.set_property('flags', flags)
         return False
 
 


### PR DESCRIPTION
The current implementation of `mute()` for the gstreamer backend sets the `'mute'` property of the playbin. However, this seems to be completely ignored, at least while in the `READY` or `PAUSED` state. (Maybe it would work in the `PLAYING` state, I haven't tried.)

This PR goes a different route by completely disabling or enabling audio for the playbin via its `'flags'` property. This works fine in the `READY` state and fixes #277. I haven't been able to figure out whether the [`0x02` constant](https://gstreamer.freedesktop.org/documentation/playback/playsink.html?gi-language=python#GstPlayFlags) lives under some name in Python land.

Disclaimer: I haven't tested whether this also works in the `PAUSED` or `PLAYING` state, as `mute()` is currently only called upon initialization of a document page, as far as I know.