### PR TITLE
Make timing breakdown columns resizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 build/
 dist/
+# ignore virtual env environments
+env/
 
 pympress.egg-info/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *.pyc
 build/
 dist/
-# ignore virtual env environments
-env/
 
 pympress.egg-info/
 

--- a/pympress/share/xml/time_report_dialog.glade
+++ b/pympress/share/xml/time_report_dialog.glade
@@ -50,6 +50,7 @@
                   <object class="GtkTreeViewColumn" id="name_renderer">
                     <property name="title" translatable="yes">name</property>
                     <property name="expand">True</property>
+                    <property name="resizable">True</property>
                     <child>
                       <object class="GtkCellRendererText"/>
                       <attributes>
@@ -61,6 +62,7 @@
                 <child>
                   <object class="GtkTreeViewColumn" id="time_renderer">
                     <property name="min_width">60</property>
+                    <property name="resizable">True</property>
                     <property name="title" translatable="yes">time</property>
                     <child>
                       <object class="GtkCellRendererText"/>
@@ -73,6 +75,7 @@
                 <child>
                   <object class="GtkTreeViewColumn" id="duration_renderer">
                     <property name="min_width">60</property>
+                    <property name="resizable">True</property>
                     <property name="title" translatable="yes">duration</property>
                     <child>
                       <object class="GtkCellRendererText"/>
@@ -85,6 +88,7 @@
                 <child>
                   <object class="GtkTreeViewColumn" id="page_renderer">
                     <property name="min_width">60</property>
+                    <property name="resizable">True</property>
                     <property name="title" translatable="yes">slide</property>
                     <child>
                       <object class="GtkCellRendererText">


### PR DESCRIPTION
This PR makes the timing breakdown columns re sizable. When first opening, they are rendered all clumped up in ubuntu, expanding only the name column. 

With this PR, their width is changeable, as shown in the video.

[Screencast from 16-09-23 17:08:51.webm](https://github.com/Cimbali/pympress/assets/2617411/227a3956-c174-4369-bea4-43e8a7513301)
