### PR TITLE
Fix two bugs related to the layout

### DIFF
--- a/pympress/config.py
+++ b/pympress/config.py
@@ -516,6 +516,6 @@ class Config(configparser.ConfigParser, object):  # python 2 fix
             widget (:class:`~Gtk.Widget`): the widget that will contain the layout.
             pane_handle_pos (`dict`): Map of :class:`~Gtk.Paned` to the relative handle position (float in 0..1)
         """
-        if layout_name not in self.static_layout:
+        if layout_name in self.static_layout:
             return
         self.update_layout_tree(layout_name, self.widget_layout_to_tree(widget, pane_handle_pos))

--- a/pympress/ui.py
+++ b/pympress/ui.py
@@ -1749,7 +1749,7 @@ class UI(builder.Builder):
         """
         if new is None:
             new = self.layout_name(self.notes_mode)
-        else:
+        elif new != 'deck-overview':
             self.layout_editor.set_current_layout(new)
 
         pane_handles = self.replace_layout(self.config.get_layout(new), self.p_central,

--- a/pympress/ui.py
+++ b/pympress/ui.py
@@ -1732,7 +1732,7 @@ class UI(builder.Builder):
         if self.scribbler.scribbling_mode:
             return 'highlight'
         elif self.deck.deck_mode:
-            return 'deck'
+            return 'deck-overview'
         elif notes_mode.direction() == 'page number':
             return 'note_pages'
         elif notes_mode:


### PR DESCRIPTION
Hi, thank you for maintaining this helpful tool :smiley:  Pympress has been one of my favorite tools since I started researching as a CS graduate student a few years ago.

I made this PR with my two commits that fix two bugs each other in `master`. Sorry to include two fixes in one PR, but they are tiny and interrelated, so it'll be better to pack them.

## 1. Layout changes not saved

As far as I confirmed, the current Pympress does not save and restore any layout changes.

###  How to reproduce

1. Launch it.
2. Make any layout change, e.g., move the center vertical bar almost to the left edge.
3. Exit and relaunch.
4. The center vertical bar backs to the original position, not the left edge.

After applying this PR, the vertical bar position is restored as the same as 2.

## 2. Cannot open "Edit layout" dialog

Pympress fails to open "Edit layout" dialog in the "Starting Configuration" menu with an error message in the console.

###  How to reproduce

1. Launch it.
2. Show "Deck overview" (even if no file opened)
3. Click "Starting Configuration" -> "Edit layout"

After the 3, I got a message:

```log
Traceback (most recent call last):
  File ".../.local/pipx/venvs/pympress/lib/python3.11/site-packages/pympress/dialog.py", line 463, in show_editor
    self.load_layout()
  File ".../.local/pipx/venvs/pympress/lib/python3.11/site-packages/pympress/dialog.py", line 259, in load_layout
    self.layout_description.set_text(self.layout_descriptions[self.current_layout])
                                     ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: 'deck-overview'
```

I can also reproduce after the deck is closed and opened twice or more.

After this PR, the edit dialog opens without the error message.