### PR TITLE
Use underscore-separated fields in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ mapping_file = pympress/share/locale/babel_mapping.cfg
 [compile_catalog]
 domain = pympress
 directory = pympress/share/locale/
-use-fuzzy = false
+use_fuzzy = false
 statistics = true
 
 [pysrpm]


### PR DESCRIPTION
setuptools >= 78 is stricter about this.

Fixes: #332