### PR TITLE
Feature: Remember, save, and load highlights across slides

### DIFF
--- a/pympress/deck.py
+++ b/pympress/deck.py
@@ -142,40 +142,48 @@ class Overview(builder.Builder):
         """
         pages = self.get_last_label_pages() if not self.all_pages and self.has_labels() else range(self.pages_number())
         self.grid_size = (len(pages), 1)
+        for child in self.deck_grid.get_children():
+            self.deck_grid.remove(child)
 
-        # Always keep the first drawing area as it is used to provide surfaces in the cache
-        for row in range(1, self.grid_size[0]):
-            self.deck_grid.remove_row(row)
-        for col in range(1, self.grid_size[1]):
-            self.deck_grid.remove_row(col)
+        if not hasattr(self, 'deck_da_list') or not self.deck_da_list:
+            self.deck_da_list = [self.deck0]
+        else:
+            self.deck_da_list = [self.deck_da_list[0]]
 
-        # Set drawing areas
-        for num, da in enumerate(self.deck_da_list[1:], 1):
-            self.deck_grid.attach(da.get_parent(), 1, num, 1, 1)
+        for num in range(len(pages)):
+            if num == 0:
+                da = self.deck0
+            else:
+                da = Gtk.DrawingArea()
+                da.add_events(Gdk.EventMask.TOUCH_MASK | Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK |
+                              Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON_RELEASE_MASK)
+                da.connect('draw', self.on_deck_draw)
+                da.connect('button-release-event', self.on_deck_click)
+                da.connect('touch-event', self.on_deck_click)
+                da.connect('enter-notify-event', self.on_deck_hover)
+                da.connect('leave-notify-event', self.on_deck_hover)
+                self.deck_da_list.append(da)
 
-        for num in range(len(self.deck_da_list), len(pages)):
-            da = Gtk.DrawingArea()
-            da.add_events(Gdk.EventMask.TOUCH_MASK | Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK |
-                          Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON_RELEASE_MASK)
-            da.connect('draw', self.on_deck_draw)
-            da.connect('button-release-event', self.on_deck_click)
-            da.connect('touch-event', self.on_deck_click)
-            da.connect('enter-notify-event', self.on_deck_hover)
-            da.connect('leave-notify-event', self.on_deck_hover)
-            self.deck_da_list.append(da)
+            current_parent = da.get_parent()
+            if current_parent is not None:
+                current_parent.remove(da)
 
             frame = Gtk.AspectFrame()
             frame.get_style_context().add_class('grid-frame')
             frame.set_shadow_type(Gtk.ShadowType.NONE)
             frame.add(da)
 
-            self.deck_grid.attach(frame, 1, num, 1, 1)
+            self.deck_grid.attach(frame, 0, num, 1, 1)
 
-        ratio = self.c_da.get_allocated_width() / self.c_da.get_allocated_height()
-        for page, da in zip(pages, self.deck_da_list):
-            da.get_parent().set(.5, .5, ratio, False)
-            da.set_name('deck{}'.format(page))
+        alloc = self.c_da.get_allocated_width(), self.c_da.get_allocated_height()
+        ratio = alloc[0] / alloc[1] if alloc[1] > 0 else 1.3
 
+        for page_idx, da in zip(pages, self.deck_da_list):
+            p = da.get_parent()
+            if p:
+                p.set(.5, .5, ratio, False)
+            da.set_name('deck{}'.format(page_idx))
+            
 
     def reset_grid(self, *args):
         """ Set the slides configuration and size in the grid

--- a/pympress/document.py
+++ b/pympress/document.py
@@ -1203,6 +1203,25 @@ class Document(object):
         return self.uri
 
 
+    @staticmethod
+    def scribble_data_path(uri):
+        """ Path to the JSON file used to save scribbles for a PDF (.pdf.json)."""
+        if not uri:
+            return None
+        uri_parts = urlsplit(uri)
+        if uri_parts.scheme != 'file':
+            return None
+        path_s = url2pathname(uri_parts.path)
+        if len(path_s) >= 3 and path_s[0] in '/\\' and path_s[2] == ':':
+            path_s = path_s.lstrip('/\\')
+        p = pathlib.Path(path_s)
+        try:
+            p = p.resolve()
+        except OSError:
+            pass
+        return p.parent / (p.name + '.json')
+
+
     def get_full_path(self, filename):
         """ Returns full path, extrapolated from a path relative to this document or to the current directory.
 

--- a/pympress/scribble.py
+++ b/pympress/scribble.py
@@ -27,13 +27,72 @@ import logging
 logger = logging.getLogger(__name__)
 
 import math
-
+import json
 import gi
 import cairo
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GLib
 
-from pympress import builder, extras, util
+from pympress import builder, document, extras, util
+
+
+def clone_strokes(strokes):
+    """ Deep-copy stroke tuples - remembered pages do not share point lists with 'scribble_list'.  """
+    out = []
+    for item in strokes:
+        if not isinstance(item, (list, tuple)) or len(item) < 4:
+            continue
+        color, width, points, pressure = item[0], item[1], item[2], item[3]
+        c = Gdk.RGBA()
+        try:
+            c.red, c.green, c.blue, c.alpha = color.red, color.green, color.blue, color.alpha
+        except AttributeError:
+            continue
+        pts = [(float(x), float(y)) for x, y in points] if points else []
+        pr = [float(p) for p in pressure] if pressure else []
+        out.append((c, width, pts, pr))
+    return out
+
+
+def serialize_strokes(strokes):
+    """ Serialize strokes for JSON (coordinates are relative to the slide). 'strokes' must be a list of (Gdk.RGBA, width, points, pressure)"""
+    data = []
+    for color, width, points, pressure in strokes:
+        if not points:
+            continue
+        pr = list(pressure)
+        while len(pr) < len(points):
+            pr.append(1.0)
+        try:
+            cs = color.to_string()
+        except Exception:
+            logger.warning('Could not serialize highlight color, using black', exc_info=True)
+            cs = 'rgb(0,0,0)'
+        data.append({
+            'c': cs,
+            'w': width,
+            'p': [[float(x), float(y)] for x, y in points],
+            'P': [float(p) for p in pr[:len(points)]],
+        })
+    return data
+
+
+def deserialize_strokes(data):
+    """ Restore strokes from output. """
+    strokes = []
+    for item in data:
+        try:
+            color = Gdk.RGBA()
+            if not color.parse(item['c']):
+                continue
+            width = int(round(float(item['w'])))
+            points = [(float(x), float(y)) for x, y in item['p']]
+            pressure = [float(p) for p in item['P']]
+        except (KeyError, TypeError, ValueError):
+            logger.warning('Skipping invalid entry when loading highlights file', exc_info=True)
+            continue
+        strokes.append((color, width, points, pressure))
+    return strokes
 
 
 class Scribbler(builder.Builder):
@@ -120,6 +179,10 @@ class Scribbler(builder.Builder):
     start_zooming = lambda *args: None
     #: callback, to be connected to :func:`~pympress.extras.Zoom.stop_zooming`
     stop_zooming = lambda *args: None
+    #: callback return current preview page index 
+    get_preview_page_number = lambda *args: 0
+    #: callback return current preview page label string
+    get_preview_page_label = lambda *args: ''
 
     #: `int` that is the currently selected element
     active_preset = -1
@@ -135,17 +198,16 @@ class Scribbler(builder.Builder):
     #: The :class:`~Gio.Action` that contains the currently selected pen
     pen_action = None
 
-    #: `str` which is the mode for scribbling, one of 3 possible values:
-    # global means one set of scribbles for the whole document
-    # single-page means we manage a single page of scribbles, and clear everything on page change (historical behaviour)
-    # per-page means we manage a set of scribbles per document page, and clear or restore them on page change
-    # per-label means we manage a set of scribbles per document page, but defined by label and not page number
-    highlight_mode = 'single-page'
+    #: `str` which is the mode for scribbling, one of 4 possible values:
+    # global and per-page: per_page[int slide_index] holds strokes for that slide; active slide also uses scribble_list
+    # single-page clears scribble_list on page change (per_page still updated for export of current slide)
+    # per-label uses per_page[str label] as key instead of slide index
+    highlight_mode = 'per-page'
     #: `bool` indicating whether we exit highlighting mode on page change
     page_change_exits = True
 
-    #: `dict` of scribbles per page
-    remembered_scribbles = {}
+    #: All slides strokes: keys are slide index (int) or label ('str' in per-label mode); values match scribble_list shape.
+    per_page = {}
     #: `tuple` of (`int`, `str`) indicating the current page number and label
     current_page = (None, None)
 
@@ -172,9 +234,16 @@ class Scribbler(builder.Builder):
         self.load_layout = builder.get_callback_handler('load_layout')
         self.redraw_current_slide = builder.get_callback_handler('redraw_current_slide')
         self.resize_cache = builder.get_callback_handler('cache.resize_widget')
-        self.get_slide_point = builder.get_callback_handler('zoom.get_slide_point')
+        gsp = builder.get_callback_handler('zoom.get_slide_point')
+        self.get_slide_point = gsp if callable(gsp) else self.fallback_slide_point
+        if not callable(gsp):
+            logger.error('.get_slide_point is not available; using widget-normalized coordinates only')
         self.start_zooming = builder.get_callback_handler('zoom.start_zooming')
         self.stop_zooming = builder.get_callback_handler('zoom.stop_zooming')
+        gpn = builder.get_callback_handler('get_preview_page_number')
+        self.get_preview_page_number = gpn if callable(gpn) else (lambda: 0)
+        gpl = builder.get_callback_handler('get_preview_page_label')
+        self.get_preview_page_label = gpl if callable(gpl) else (lambda: '')
 
         self.connect_signals(self)
         self.config = config
@@ -251,10 +320,85 @@ class Scribbler(builder.Builder):
         self.get_application().lookup_action('highlight-mode').change_state(GLib.Variant.new_string(new_mode))
         self.highlight_mode = new_mode
         self.config.set('highlight', 'mode', self.highlight_mode)
-        self.remembered_scribbles.clear()
+        self.per_page.clear()
 
         return True
 
+
+    def storage_key_for_active_slide(self):
+        """ Key into 'per_page' for the slide being drawn (int index or str label). """
+        if self.highlight_mode == 'per-label':
+            if self.current_page[0] is not None:
+                return self.current_page[1] or ''
+            fn = self.get_preview_page_label
+            if callable(fn):
+                try:
+                    return (fn() or '')
+                except TypeError:
+                    pass
+            return ''
+        idx = self.current_page[0]
+        if idx is not None:
+            return int(idx)
+        fn = self.get_preview_page_number
+        if callable(fn):
+            try:
+                return int(fn())
+            except (TypeError, ValueError):
+                pass
+        return 0
+
+
+    def fallback_slide_point(self, widget, event):
+        """ If 'get_slide_point' is missing, use pointer size only (no zoom correction). """
+        ww = max(widget.get_allocated_width(), 1)
+        wh = max(widget.get_allocated_height(), 1)
+        ex, ey = event.get_coords()
+        return ex / ww, ey / wh
+
+
+    def event_to_slide_coordinates(self, widget, event):
+        """ Normalized slide coordinates from pointer position; uses widget w/h and zoom (not Cairo pixels). """
+        ww = widget.get_allocated_width()
+        wh = widget.get_allocated_height()
+        if ww < 1 or wh < 1:
+            logger.warning('highlight: widget size %sx%s too small for coordinates', ww, wh)
+            return 0.0, 0.0
+        fn = self.get_slide_point
+        if not callable(fn):
+            logger.error('highlight: get_slide_point is not callable')
+            return self.fallback_slide_point(widget, event)
+        try:
+            pt = fn(widget, event)
+        except Exception:
+            logger.exception('highlight: get_slide_point failed')
+            return self.fallback_slide_point(widget, event)
+        if pt is None:
+            logger.warning('highlight: get_slide_point returned None, using fallback')
+            return self.fallback_slide_point(widget, event)
+        try:
+            x, y = float(pt[0]), float(pt[1])
+        except (TypeError, ValueError, IndexError):
+            logger.warning('highlight: get_slide_point returned invalid %r, using fallback', pt)
+            return self.fallback_slide_point(widget, event)
+        if math.isnan(x) or math.isnan(y) or math.isinf(x) or math.isinf(y):
+            logger.warning('highlight: non-finite coordinates (%s, %s), clamping to 0', x, y)
+            return 0.0, 0.0
+        logger.debug('highlight: slide coords (%s, %s) widget=%s', x, y, widget.get_name())
+        return x, y
+
+
+    def sync_per_page_from_list(self):
+        """ Deep-copy 'scribble_list' into 'per_page' for the active slide."""
+        if not self.scribble_list:
+            return
+        key = self.storage_key_for_active_slide()
+        snapshot = clone_strokes(self.scribble_list)
+        self.per_page[key] = snapshot
+        points = [p for s in self.scribble_list
+                  if isinstance(s, (list, tuple)) and len(s) >= 4 and isinstance(s[2], list)
+                  for p in s[2]]
+        
 
     def try_cancel(self):
         """ Cancel scribbling, if it is enabled.
@@ -306,6 +450,21 @@ class Scribbler(builder.Builder):
         return curves
 
 
+    def ensure_active_stroke(self):
+        """ Ensure 'scribble_list' ends with a valid stroke (color, width, points, pressures)."""
+        need_new = False
+        if not self.scribble_list:
+            need_new = True
+        else:
+            stroke = self.scribble_list[-1]
+            if not isinstance(stroke, (list, tuple)) or len(stroke) < 4:
+                need_new = True
+            elif not isinstance(stroke[2], list) or not isinstance(stroke[3], list):
+                need_new = True
+        if need_new:
+            self.scribble_list.append((self.scribble_color, self.scribble_width, [], []))
+
+
     def track_scribble(self, widget, event):
         """ Draw the scribble following the mouse's moves.
 
@@ -316,16 +475,21 @@ class Scribbler(builder.Builder):
         Returns:
             `bool`: whether the event was consumed
         """
-        pos = self.get_slide_point(widget, event) + ()
+        pos = self.event_to_slide_coordinates(widget, event) + ()
 
         if self.scribble_drawing:
-            self.scribble_list[-1][-2].append(pos)
+            self.ensure_active_stroke()
+            stroke = self.scribble_list[-1]
+            points = stroke[2]
+            pressures = stroke[3]
+            points.append(pos)
             pressure = event.get_axis(Gdk.AxisUse.PRESSURE)
-            self.scribble_list[-1][-1].append(1. if pressure is None else pressure)
+            pressures.append(1. if pressure is None else pressure)
             self.scribble_redo_list.clear()
 
             self.adjust_buttons()
-
+            self.sync_per_page_from_list()
+            key = self.storage_key_for_active_slide()
         self.mouse_pos = pos
         self.redraw_current_slide()
         return self.scribble_drawing
@@ -389,6 +553,11 @@ class Scribbler(builder.Builder):
             return self.track_scribble(widget, event)
         elif event.get_event_type() == Gdk.EventType.BUTTON_RELEASE:
             self.scribble_drawing = False
+            last = self.scribble_list[-1] if self.scribble_list else None
+            if last is not None and isinstance(last, (list, tuple)) and len(last) >= 4 \
+                    and isinstance(last[2], list) and not last[2]:
+                self.scribble_list.pop()
+            self.sync_per_page_from_list()
             self.prerender()
 
             if not self.active_preset and self.previous_preset and self.toggle_erase_source == 'modifier':
@@ -402,62 +571,22 @@ class Scribbler(builder.Builder):
 
 
     def reset_scribble_cache(self):
-        """ Clear the cached scribbles.
-        """
-        window = self.c_da.get_window()
+        """ Highlights are drawn from vector data. This function is called when the cache needs to be cleared, on page change or mode change. """
+        self.scribble_cache = None
+        self.next_render = 0
 
-        if window is None:
-            logger.error('Cannot initialize scribble cache without drawing area window')
-            return
 
-        scale = window.get_scale_factor()
-        ww, wh = self.c_da.get_allocated_width() * scale, self.c_da.get_allocated_height() * scale
-        try:
-            self.scribble_cache = window.create_similar_image_surface(cairo.Format.ARGB32, ww, wh, scale)
-        except ValueError as e:
-            if e.args == ('invalid enum value: 5',):
-                # Just try again as this error seems to always happen at the first call but not later on
-                # This is the gi introspection of cairo not accepting the value Format.RGB30 (???)
-                try:
-                    self.scribble_cache = window.create_similar_image_surface(cairo.Format.ARGB32, ww, wh, scale)
-                except ValueError:
-                    logger.exception('Error creating highlight cache')
-                else:
-                    self.next_render = 0
-            else:
-                logger.exception('Error creating highlight cache')
-        except cairo.Error:
-            logger.warning('Failed creating an ARGB32 surface sized {}x{} scale {} for highlight cache'
-                           .format(ww, wh, scale), exc_info=True)
-        else:
-            self.next_render = 0
+    def queue_draw(self):
+        """ Queue GTK redraw on drawing areas that show highlights. """
+        if self.c_da is not None:
+            self.c_da.queue_draw()
+        if self.scribble_p_da is not None:
+            self.scribble_p_da.queue_draw()
 
 
     def prerender(self):
-        """ Commit scribbles to cache so they are faster to draw on the slide
-        """
-        if self.scribble_cache is None:
-            self.reset_scribble_cache()
-
-        if self.scribble_cache is None:
-            self.next_render = 0
-            return
-
-        scale = self.c_da.get_window().get_scale_factor()
-        ww, wh = self.scribble_cache.get_width() / scale, self.scribble_cache.get_height() / scale
-        pen_scale_factor = max(ww / 900, wh / 900)  # or sqrt of product
-
-        cairo_context = cairo.Context(self.scribble_cache)
-        cairo_context.set_line_cap(cairo.LINE_CAP_ROUND)
-
-        draw = slice(self.next_render, -1 if self.scribble_drawing else None)
-
-        for color, width, points, pressure in self.scribble_list[draw]:
-            self.render_scribble(cairo_context, color, width * pen_scale_factor, [(x * ww, y * wh) for x, y in points],
-                                 pressure)
-        del cairo_context
-
-        self.next_render = draw.indices(len(self.scribble_list))[1]
+        """ Keep 'per_page' in sync after a stroke ends (drawing is vector-based)."""
+        self.sync_per_page_from_list()
 
 
     def render_scribble(self, cairo_context, color, width, points, pressures):
@@ -472,6 +601,10 @@ class Scribbler(builder.Builder):
         """
         if not points:
             return
+
+        pressures = list(pressures)
+        while len(pressures) < len(points):
+            pressures.append(1.0)
 
         # Draw every stroke on a separate surface, then merge them all into the scribble cache
         # Erasers do not have their own group as they are meant to interfere with strokes below
@@ -509,26 +642,26 @@ class Scribbler(builder.Builder):
             widget (:class:`~Gtk.DrawingArea`): The widget where to draw the scribbles.
             cairo_context (:class:`~cairo.Context`): The canvas on which to render the drawings
         """
-        scale = widget.get_window().get_scale_factor()
-        ww, wh = widget.get_allocated_width(), widget.get_allocated_height()
-        cw, ch = self.scribble_cache.get_width(), self.scribble_cache.get_height()
+        window = widget.get_window()
+        if window is None:
+            return
+        if self.scribble_list:
+            self.sync_per_page_from_list()
+        key = self.storage_key_for_active_slide()
+        strokes = self.scribble_list if self.scribble_list else self.per_page.get(key, [])
+
+        ww = max(widget.get_allocated_width(), 1)
+        wh = max(widget.get_allocated_height(), 1)
+        pen_scale_factor = max(ww / 900, wh / 900)
 
         cairo_context.push_group()
+        cairo_context.set_line_cap(cairo.LINE_CAP_ROUND)
 
-        cairo_context.save()
-
-        cairo_context.scale(ww * scale / cw, wh * scale / ch)
-        cairo_context.set_source_surface(self.scribble_cache)
-        cairo_context.paint()
-
-        cairo_context.restore()
-
-        pen_scale_factor = max(ww / 900, wh / 900)  # or sqrt of product
-        if self.scribble_drawing:
-            cairo_context.set_line_cap(cairo.LINE_CAP_ROUND)
-            color, width, points, pressure = self.scribble_list[-1]
-            self.render_scribble(cairo_context, color, width * pen_scale_factor, [(x * ww, y * wh) for x, y in points],
-                                 pressure)
+        for color, width, points, pressure in strokes:
+            if not points:
+                continue
+            self.render_scribble(cairo_context, color, width * pen_scale_factor,
+                                 [(x * ww, y * wh) for x, y in points], pressure)
 
         cairo_context.pop_group_to_source()
         cairo_context.paint()
@@ -595,10 +728,144 @@ class Scribbler(builder.Builder):
         """ Callback for the scribble clear button, to remove all scribbles.
         """
         self.scribble_list.clear()
+        self.per_page[self.storage_key_for_active_slide()] = []
 
         self.reset_scribble_cache()
         self.redraw_current_slide()
         self.adjust_buttons()
+
+
+    def build_scribbles_save_payload(self, page_number, page_label):
+        """ Build JSON-ready data for the active highlight mode, including the current slide."""
+        key = self.storage_key_for_active_slide()
+        current_json = serialize_strokes(clone_strokes(self.scribble_list))
+        if self.highlight_mode == 'per-label':
+            out = {str(k): serialize_strokes(v) for k, v in self.per_page.items()}
+            out[str(key)] = current_json
+            return {'per_label': out}
+        out = {str(k): serialize_strokes(v) for k, v in self.per_page.items()}
+        out[str(key)] = current_json
+        return {'per_page': out}
+
+
+    def save_scribbles_data(self, uri, page_number, page_label):
+        """ Write scribbles for 'uri' to '.pdf.json' next to the PDF. """
+        path = document.Document.scribble_data_path(uri)
+        if path is None:
+            return
+
+        self.sync_per_page_from_list()
+
+        existing = {}
+        if path.is_file():
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    existing = json.load(f)
+            except (OSError, ValueError, json.JSONDecodeError):
+                logger.warning('Could not read existing highlights file {}, overwriting'.format(path), exc_info=True)
+
+        self.sync_per_page_from_list()
+
+        payload = {'version': 1}
+        payload.update(self.build_scribbles_save_payload(page_number, page_label))
+
+        existing['version'] = 1
+        for key in ('global', 'per_page', 'per_label'):
+            if key not in payload:
+                continue
+            if key in existing and isinstance(existing[key], dict) and isinstance(payload[key], dict):
+                merged = dict(existing[key])
+                merged.update(payload[key])
+                existing[key] = merged
+            else:
+                existing[key] = payload[key]
+
+        tmp_path = path.parent / (path.name + '~')
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self.sync_per_page_from_list()
+            payload_final = self.build_scribbles_save_payload(page_number, page_label)
+            for mkey in ('per_page', 'per_label'):
+                if mkey not in payload_final:
+                    continue
+                if mkey in existing and isinstance(existing[mkey], dict) and isinstance(payload_final[mkey], dict):
+                    existing[mkey].update(payload_final[mkey])
+                else:
+                    existing[mkey] = payload_final[mkey]
+            with open(tmp_path, 'w', encoding='utf-8') as f:
+                json.dump(existing, f, indent=2, ensure_ascii=False)
+                f.flush()
+            tmp_path.replace(path)
+            sec = payload_final.get('per_page') or payload_final.get('per_label') or {}
+            n_strokes = sum(len(v) for v in sec.values() if isinstance(v, list))
+        except OSError:
+            logger.exception('Failed to write highlights file {}'.format(path))
+            if tmp_path.is_file():
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
+
+
+    def load_scribbles_data(self, uri, page_number, page_label):
+        """ Load scribbles from the JSON. """
+        path = document.Document.scribble_data_path(uri)
+
+        if path is None:
+            self.scribble_redo_list.clear()
+            self.per_page.clear() 
+            self.scribble_list.clear() 
+            self.reset_scribble_cache() 
+            self.adjust_buttons() 
+            self.redraw_current_slide() 
+            return
+        
+        self.scribble_redo_list.clear()
+        self.current_page = (None, None)
+        page_label = page_label or ''
+
+        self.per_page.clear()
+        self.scribble_list.clear()
+
+        if path is None or not path.is_file():
+            self.reset_scribble_cache()
+            self.adjust_buttons()
+            self.redraw_current_slide()
+            return
+
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except (OSError, ValueError, json.JSONDecodeError):
+            logger.warning('Invalid highlights file {}, ignoring'.format(path), exc_info=True)
+            self.reset_scribble_cache()
+            self.adjust_buttons()
+            self.redraw_current_slide()
+            return
+
+        if self.highlight_mode in ('global', 'per-page'):
+            per = data.get('per_page', {})
+            if not per and data.get('global'):
+                self.per_page[page_number] = deserialize_strokes(data['global'])
+            else:
+                for k, v in per.items():
+                    try:
+                        ki = int(k)
+                    except (TypeError, ValueError):
+                        continue
+                    self.per_page[ki] = deserialize_strokes(v)
+        elif self.highlight_mode == 'per-label':
+            for k, v in data.get('per_label', {}).items():
+                self.per_page[k] = deserialize_strokes(v)
+        else:
+            per = data.get('per_page', {})
+            self.scribble_list[:] = deserialize_strokes(per.get(str(page_number), []))
+
+        self.reset_scribble_cache()
+        self.adjust_buttons()
+        if self.scribble_list or self.per_page:
+            self.prerender()
+        self.redraw_current_slide()
 
 
     def page_change(self, page_number, page_label):
@@ -608,31 +875,41 @@ class Scribbler(builder.Builder):
             page_number (`int`): The number of the new page
             page_label (`str`): The label of the new page
         """
-        if self.highlight_mode == 'per-page':
-            current_page = self.current_page[0]
-            new_page = page_number
-        elif self.highlight_mode == 'per-label':
-            current_page = self.current_page[1]
-            new_page = page_label
+        page_label = page_label or ''
+        prev_idx, prev_lbl = self.current_page
 
-        # Remember whatever the current mode, to facilitate switching modes
-        self.current_page = (page_number, page_label)
-
-        if self.highlight_mode == 'global':
+        if self.highlight_mode == 'single-page':
+            if prev_idx is not None:
+                self.clear_scribble()
+            self.current_page = (page_number, page_label)
             return
-        elif self.highlight_mode == 'single-page':
-            return self.clear_scribble()
-        else:
-            # Now optionally save the current scribbles
-            if current_page is not None and self.scribble_list:
-                self.remembered_scribbles[current_page] = self.scribble_list.copy()
 
-            self.scribble_list = self.remembered_scribbles.pop(new_page, [])
-
+        if self.highlight_mode == 'per-label':
+            if prev_idx is not None:
+                self.sync_per_page_from_list()
+            stored = self.per_page.pop(page_label, [])
+            self.scribble_list.clear()
+            self.scribble_list.extend(clone_strokes(stored))
+            self.current_page = (page_number, page_label)
             self.reset_scribble_cache()
+            self.queue_draw()
             self.adjust_buttons()
             self.prerender()
             self.redraw_current_slide()
+            return
+
+        if prev_idx is not None:
+            self.sync_per_page_from_list()
+        stored = self.per_page.pop(page_number, [])
+        self.scribble_list.clear()
+        self.scribble_list.extend(clone_strokes(stored))
+        self.current_page = (page_number, page_label)
+
+        self.reset_scribble_cache()
+        self.queue_draw()
+        self.adjust_buttons()
+        self.prerender()
+        self.redraw_current_slide()
 
 
     def pop_scribble(self, *args):
@@ -642,6 +919,7 @@ class Scribbler(builder.Builder):
             self.scribble_redo_list.append(self.scribble_list.pop())
 
         self.adjust_buttons()
+        self.sync_per_page_from_list()
         self.reset_scribble_cache()
         self.prerender()
         self.redraw_current_slide()
@@ -654,6 +932,7 @@ class Scribbler(builder.Builder):
             self.scribble_list.append(self.scribble_redo_list.pop())
 
         self.adjust_buttons()
+        self.sync_per_page_from_list()
         self.prerender()
         self.redraw_current_slide()
 

--- a/pympress/share/defaults.conf
+++ b/pympress/share/defaults.conf
@@ -166,7 +166,7 @@ width_8 = 5
 color_9 = rgb(136,136,136)
 width_9 = 48
 active_pen = 9
-mode = single-page
+mode = per-page
 page_change_exits = on
 
 [gstreamer]
@@ -209,7 +209,8 @@ cancel-input = Escape
 # prompt to open file
 pick-file = o
 close-file = <ctrl>w
-save-file = <ctrl>s
+save-scribbles-json = <ctrl>s
+save-file = <ctrl><alt>s
 save-file-as = <ctrl><shift>s
 
 pointer-mode::toggle = l

--- a/pympress/ui.py
+++ b/pympress/ui.py
@@ -245,6 +245,7 @@ class UI(builder.Builder):
             'close-file':        dict(activate=self.close_file),
             'save-file':         dict(activate=self.save_file),
             'save-file-as':      dict(activate=self.save_file_as),
+            'save-scribbles-json': dict(activate=self.save_scribbles_json),
             'pick-file':         dict(activate=self.pick_file),
             'list-recent-files': dict(change_state=self.populate_recent_menu, state=False),
             'page':              dict(activate=lambda gaction, param: self.goto_page(param.get_int64()),
@@ -726,6 +727,11 @@ class UI(builder.Builder):
     def cleanup(self, *args):
         """ Save configuration and exit the main loop.
         """
+        if self.doc is not None and self.doc.doc is not None:
+            cp = self.doc.page(self.preview_page)
+            cl = cp.label() if cp else ''
+            self.scribbler.save_scribbles_sidecar(self.doc.get_uri(), self.preview_page, cl or '')
+
         self.scribbler.disable_scribbling()
         self.medias.hide_all()
 
@@ -783,6 +789,11 @@ class UI(builder.Builder):
                 self.file_watcher.stop_watching()
             return
 
+        if self.doc is not None and self.doc.doc is not None:
+            old_preview = self.doc.page(self.preview_page)
+            old_label = old_preview.label() if old_preview else ''
+            self.scribbler.save_scribbles_sidecar(self.doc.get_uri(), self.preview_page, old_label or '')
+
         run_gc = self.doc.doc is not None
         try:
             self.doc = document.Document.create(self, doc_uri)
@@ -803,6 +814,10 @@ class UI(builder.Builder):
             self.file_watcher.stop_watching()
 
         self.current_page = self.preview_page = self.doc.goto(page)
+
+        load_preview = self.doc.page(self.preview_page)
+        load_label = load_preview.label() if load_preview else ''
+        self.scribbler.load_scribbles_sidecar(self.doc.get_uri(), self.preview_page, load_label or '')
 
         # Guess notes mode by default if the document has notes
         if not reloading:
@@ -977,7 +992,10 @@ class UI(builder.Builder):
         # Use a GTK file dialog to choose file
         dialog = Gtk.FileChooserDialog(title = _('Open...'), transient_for = self.p_win,
                                        action = Gtk.FileChooserAction.OPEN)
-        dialog.add_buttons(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        dialog.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OPEN, Gtk.ResponseType.OK,
+        )
         dialog.set_default_response(Gtk.ResponseType.OK)
         dialog.set_position(Gtk.WindowPosition.CENTER)
 
@@ -992,12 +1010,14 @@ class UI(builder.Builder):
         file_filter.add_pattern('*')
         dialog.add_filter(file_filter)
 
-        response = dialog.run()
-
-        if response == Gtk.ResponseType.OK:
-            self.swap_document(dialog.get_uri())
-
-        dialog.destroy()
+        try:
+            response = dialog.run()
+            if response == Gtk.ResponseType.OK:
+                uri = dialog.get_uri()
+                if uri:
+                    self.swap_document(uri)
+        finally:
+            dialog.destroy()
 
 
     def error_opening_file(self, uri):
@@ -1025,6 +1045,27 @@ class UI(builder.Builder):
         """ Remove the current document.
         """
         self.swap_document(None)
+
+
+    def get_preview_page_number(self):
+        """ Slide index used for highlight storage. """
+        return self.preview_page
+
+
+    def get_preview_page_label(self):
+        """ Page label for the previewed slide (per-label highlight mode). """
+        page = self.doc.page(self.preview_page) if self.doc else None
+        return (page.label() or '') if page else ''
+
+
+    def save_scribbles_json(self, *args):
+        """ Write scribble data to the PDF sidecar JSON (.pdf.json). """
+        if self.doc is None or self.doc.doc is None:
+            return
+        page = self.doc.page(self.preview_page)
+        label = (page.label() or '') if page else ''
+        self.scribbler.sync_per_page_from_list()
+        self.scribbler.save_scribbles_sidecar(self.doc.get_uri(), self.preview_page, label)
 
 
     def save_file(self, *args):


### PR DESCRIPTION
This Pull Request introduces a new functionality to remember, save, and load drawings (highlights) across presentation slides. Previously, the application only offered basic drawing capabilities where strokes were automatically cleared upon transitioning to another slide, without any option to keep them.

- Drawings are saved to and loaded from a `.pdf.json` file located in the same directory as the presentation.
- The previous implementation drew strokes into the Cairo cache (`scribble_cache`), which required regeneration every time the window was resized. The new version stores all data as normalized vectors.
- Added an "Exit highlight on page change" option that automatically exits the drawing mode when switching to a different slide

Available Modes:

- Clear on page change (single-page): Keeps the original behavior where all drawings are erased when moving to another slide.
- Never clear / manually only (global): Drawings remain visible across all slides and must be cleared manually.
- Clear and restore per page number (per-page): Each slide maintains its own set of drawings, identified and restored based on its sequence number.
- Clear and restore per page label (per-label): Functions similarly to the per-page mode, but uses the slide's text label as the key.

Technical Details:

- `document.py`: Added the scribble_data_path method to locate the path to the save file.
- `scribble.py`: Implemented methods for reading and writing the JSON file. This includes the use of a temporary file to prevent data loss during saving.
- `ui.py`: Added calls to these save/load methods during slide changes and document open/close events.
- Data Structure Update: Replaced the original `remembered_scribbles` data structure with a per page structure that is used across all drawing modes. The key for this structure is either an integer slide index (for global and per-page modes) or a label (for per-label mode).